### PR TITLE
Update SwiftFactory.php

### DIFF
--- a/lib/private/Files/ObjectStore/SwiftFactory.php
+++ b/lib/private/Files/ObjectStore/SwiftFactory.php
@@ -174,6 +174,7 @@ class SwiftFactory {
 		}
 
 		if (!$hasValidCachedToken) {
+			unset($this->params['cachedToken']);
 			try {
 				list($token, $serviceUrl) = $authService->authenticate($this->params);
 				$this->cacheToken($token, $serviceUrl, $cacheKey);


### PR DESCRIPTION
Auth-Service (in explizit v3) will recheck the cached-token and will end in an "token expired exception".